### PR TITLE
Adds note about Python 3.5

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 # convenience makefile to set up the project documentation
 
-bin = ../backend/venv/bin
+bin = ../application/venv/bin
 
 htdocs: $(bin)/sphinx-build *.rst conf.py
 	$(bin)/sphinx-build . $@

--- a/docs/bootstrap-dev.rst
+++ b/docs/bootstrap-dev.rst
@@ -23,6 +23,15 @@ Requirements
 
 You will need a local installation of Python 3.5, i.e. on macOS it is recommended to install a recent version of Python 3.5 using homebrew, i.e. `brew install python3.5`.
 
+.. NOTE::
+   If you don't have the Python 3.5 brew recipe locally you can "tap" it like this::
+
+       brew tap zoidbergwill/python
+
+   You would need to add `/usr/local/opt/python35/bin` to your PATH::
+
+       export PATH=/usr/local/opt/python35/bin/:$PATH
+
 With that in place, go into the `application` directory and run `make`::
 
     # cd application


### PR DESCRIPTION
The default Python version in homebrew repo is now 3.6. We still rely on Python 3.5...